### PR TITLE
Fix spelling mistakes identified by codespell

### DIFF
--- a/tutorials/2d/using_tilemaps.rst
+++ b/tutorials/2d/using_tilemaps.rst
@@ -169,7 +169,7 @@ Autotiles allow you to define a group of tiles, then add rules to control which
 tile gets used for drawing based on the content of adjacent cells.
 
 Click "New Autotile" and drag to select the tiles you wish to use. You can add
-collisions, occlusion, navigation shapes, tile priorties, and select an icon
+collisions, occlusion, navigation shapes, tile priorities, and select an icon
 tile in the same manner as for atlas tiles.
 
 Tile selection is controlled by bitmasks. Bitmasks can be added by clicking

--- a/tutorials/3d/using_transforms.rst
+++ b/tutorials/3d/using_transforms.rst
@@ -310,7 +310,7 @@ Setting information
 
 There are, of course, cases where you want to set information to a transform. Imagine a first person controller or orbiting camera. Those are definitely done using angles, because you *do want* the transforms to happen in a specific order.
 
-For such cases, keep the angles and rotations *outside* the transform and set them every frame. Don't try to retrieve and re-use them because the transform is not meant to be used this way.
+For such cases, keep the angles and rotations *outside* the transform and set them every frame. Don't try to retrieve and reuse them because the transform is not meant to be used this way.
 
 Example of looking around, FPS style:
 

--- a/tutorials/best_practices/scene_organization.rst
+++ b/tutorials/best_practices/scene_organization.rst
@@ -148,7 +148,7 @@ initialize it:
        GetNode(TargetPath); // Use parent-defined NodePath.
 
 These options hide the points of access from the child node. This in turn
-keeps the child **loosely coupled** to its environment. One can re-use it
+keeps the child **loosely coupled** to its environment. One can reuse it
 in another context without any extra changes to its API.
 
 .. note::

--- a/tutorials/performance/gpu_optimization.rst
+++ b/tutorials/performance/gpu_optimization.rst
@@ -88,7 +88,7 @@ possible. Godot's priorities are:
    scene, the faster the rendering will be. If a scene has a huge amount
    of objects (in the hundreds or thousands), try reusing the materials.
    In the worst case, use atlases to decrease the amount of texture changes.
--  **Reusing Shaders:** If materials can't be reused, at least try to re-use
+-  **Reusing Shaders:** If materials can't be reused, at least try to reuse
    shaders. Note: shaders are automatically reused between
    SpatialMaterials that share the same configuration (features
    that are enabled or disabled with a check box) even if they have different


### PR DESCRIPTION
Code spell has identified the following new spelling mistakes:
- `tutorials/2d/using_tilemaps.rst`:172: priorties ==> priorities, prior ties
- `tutorials/3d/using_transforms.rst`:313: re-use ==> reuse
- `tutorials/best_practices/scene_organization.rst`:151: re-use ==> reuse
- `tutorials/performance/gpu_optimization.rst`:91: re-use ==> reuse

This PR makes the recommended changes.