### PR TITLE
Update Read the Docs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,17 @@
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 version: 2
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: requirements.txt
 
 sphinx:
   configuration: conf.py
@@ -21,7 +27,3 @@ sphinx:
 # then, all offline download options are worthless.
 # (Track https://github.com/readthedocs/readthedocs.org/issues/3242)
 formats: []
-
-python:
-  install:
-    - requirements: requirements.txt


### PR DESCRIPTION
Read the Docs has deprecated the `build.image` config key in favour of `build.os`[[1](https://blog.readthedocs.com/use-build-os-config/)]

This PR updates the .readthedocs.yaml file to use `build.os` and it is set to their latest version of Ubuntu: 22.04.
This change also requires specifying the `build.tools.python` version, which on Ubuntu 22.04 is Python v3.10.

[1] Use build.os instead of build.image on your configuration file: https://blog.readthedocs.com/use-build-os-config/