### PR TITLE
Update GitHub Upload Artifact Action to v4

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload patch file
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documentation-patch
           path: |


### PR DESCRIPTION
Currently, the Check Documentation GitHub workflow is raising the following warning:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
The end-of-life date for Node.js 16 was brought forward by seven months to coincide with the end of support of OpenSSL 1.1.1 on 11th September 2023.[[1](https://nodejs.org/en/blog/announcements/nodejs16-eol/)]. This prompted GitHub to initiate the deprecation process for GitHub Actions using Node.js 16 and transition all actions to run on Node 20 by Spring 2024.[[2](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)].

This PR upgrades the documentation checks' workflow's use of [Upload Artifact](https://github.com/actions/upload-artifact) to v4. The other GitHub Action used, [Checkout](https://github.com/actions/checkout), has already been upgraded to the latest version in #8.


[1] https://nodejs.org/en/blog/announcements/nodejs16-eol/
[2] https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/