### PR TITLE
Give the workflows' jobs names

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   check-documentation:
+    name: Check Documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,6 +45,7 @@ jobs:
             documentation.patch
 
   build-documentation:
+    name: Build Documentation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/update-rebel-engine-api.yaml
+++ b/.github/workflows/update-rebel-engine-api.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update-rebel-engine-api:
+    name: Update Rebel Engine API
     # Don't run on forks.
     if: github.repository == 'RebelToolbox/RebelDocumentation'
     runs-on: ubuntu-latest


### PR DESCRIPTION
A minor cosmetic change for the workflows:
Before | After
--- | ---
![Checks Before](https://github.com/RebelToolbox/RebelDocumentation/assets/9253928/69ac55f3-a65a-4a0a-b71d-ce41b6f6dfe2) | ![Checks After](https://github.com/RebelToolbox/RebelDocumentation/assets/9253928/702c55fd-2979-41d7-8f97-86ff1ab77e0d)

Instead of lower case hyphened names, capitalised spaced names: