### PR TITLE
Fix broken references

### DIFF
--- a/api/index.rst
+++ b/api/index.rst
@@ -5,7 +5,7 @@ Rebel Engine API
 
 .. toctree::
    :maxdepth: 1
-   :name: toc-class-ref
+   :name: toc-api
    :glob:
 
    class_*

--- a/contributing/api_writing_guidelines.rst
+++ b/contributing/api_writing_guidelines.rst
@@ -10,7 +10,7 @@ built-in node types.
 .. seealso::
 
     To learn to submit your changes to the Rebel Engine project using the Git version
-    control system, see :ref:`doc_updating_the_class_reference`.
+    control system, see :ref:`doc_updating_the_api_documentation`.
 
 The reference for each class is contained in an XML file like the one below:
 

--- a/contributing/updating_the_api_documentation.rst
+++ b/contributing/updating_the_api_documentation.rst
@@ -1,14 +1,14 @@
 .. _doc_updating_the_api_documentation:
 
-Contributing to the API Documentation
-=====================================
+Contributing to the Rebel Engine API Documentation
+==================================================
 
 .. highlight:: shell
 
-The class reference is available online in the :ref:`classes <toc-class-ref>`
+The Rebel Engine API is available online in the :ref:`Rebel Engine API <toc-api>`
 section of the documentation and in the Rebel Engine editor, from the help menu.
 
-In the class reference, some methods, variables, and signals lack descriptions.
+In the Rebel Engine API, some methods, variables, and signals lack descriptions.
 Others changed with recent releases and need updates. The developers can't write
 the entire reference on their own. Rebel Toolbox needs you, and all of us, to
 contribute.
@@ -20,46 +20,46 @@ taking care of a given class.
 
 .. seealso::
 
-    You can find the writing guidelines for the class reference :ref:`here <doc_class_reference_writing_guidelines>`.
+    You can find the writing guidelines for the Rebel Engine API :ref:`here <doc_api_writing_guidelines>`.
 
     For details on Git usage and the pull request workflow, please
     refer to the :ref:`doc_pr_workflow` page.
 
-You can find the source files for the class reference in Rebel Engine's GitHub
-repository: `doc/classes/
-<https://github.com/RebelToolbox/RebelEngine/tree/main/doc/classes>`_.
+You can find the source files for the Rebel Engine API in Rebel Engine's GitHub
+repository: `docs/
+<https://github.com/RebelToolbox/RebelEngine/tree/main/docs>`_.
 
 .. note:: For some modules in the engine's source code, you'll find the XML
-          files in the ``modules/<module_name>/doc_classes/`` directory instead.
+          files in the ``modules/<module_name>/docs/`` directory instead.
 
 .. warning:: Always edit the API reference through these source XML files. Do
              not edit the generated ``.rst`` files :ref:`in the online documentation
-             <toc-class-ref>`, hosted in the `Rebel Documentation
+             <toc-api>`, hosted in the `Rebel Documentation
              <https://github.com/RebelToolbox/RebelDocumentation>`_ repository.
 
 .. warning::
 
-    Unless you make minor changes, like fixing a typo, we do not recommend using the GitHub web editor to edit the class reference's XML.
+    Unless you make minor changes, like fixing a typo, we do not recommend using the GitHub web editor to edit the Rebel Engine API's XML.
 
     It lacks features to edit XML well, like keeping indentations consistent, and it does not allow amending commits based on reviews.
 
     Also, it doesn't allow you to test your changes in the engine or with validation
     scripts as described in
-    :ref:`doc_class_reference_writing_guidelines_editing_xml`.
+    :ref:`doc_api_writing_guidelines_editing_xml`.
 
 Updating the documentation template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you create a new class or modify the engine's API, you need to re-generate the XML files in ``doc/classes/``.
+When you create a new class or modify the engine's API, you need to re-generate the XML files in ``docs/``.
 
 To do so, you first need to compile Rebel Engine. See the
 :ref:`doc_introduction_to_the_buildsystem` page to learn how. Then, execute the
 compiled Rebel Engine binary from the Rebel Engine root directory with the ``--doctool`` option.
 For example, if you're on 64-bit Linux, the command is::
 
-    ./bin/bin/rebel.x11.tools.64 --doctool
+    ./bin/rebel.x11.tools.64 --generate-docs
 
-The XML files in doc/classes should then be up-to-date with current Rebel Engine
+The XML files in ``docs/`` should then be up-to-date with current Rebel Engine
 features. You can then check what changed using the ``git diff`` command. Please
 only include changes that are relevant to your work on the API in your commits.
 You can discard changes in other XML files using ``git checkout``.


### PR DESCRIPTION
#10 didn't catch all the reference changes.

The build check does raise warnings:
```
/home/runner/work/RebelDocumentation/RebelDocumentation/contributing/api_writing_guidelines.rst:12: WARNING: undefined label: 'doc_updating_the_class_reference'
/home/runner/work/RebelDocumentation/RebelDocumentation/contributing/contributing_to_the_documentation.rst:19: WARNING: undefined label: 'toc-api'
/home/runner/work/RebelDocumentation/RebelDocumentation/contributing/documentation_guidelines.rst:26: WARNING: undefined label: 'toc-api'
/home/runner/work/RebelDocumentation/RebelDocumentation/contributing/updating_the_api_documentation.rst:23: WARNING: undefined label: 'doc_class_reference_writing_guidelines'
/home/runner/work/RebelDocumentation/RebelDocumentation/contributing/updating_the_api_documentation.rst:46: WARNING: undefined label: 'doc_class_reference_writing_guidelines_editing_xml'
/home/runner/work/RebelDocumentation/RebelDocumentation/contributing/ways_to_contribute.rst:183: WARNING: undefined label: 'toc-api'
/home/runner/work/RebelDocumentation/RebelDocumentation/getting_started/introduction/learning_new_features.rst:36: WARNING: undefined label: 'toc-api'
build succeeded, 7 warnings.
```
However, these warnings don't cause the build check to fail. This will need to be investigated separately.

This PR addresses those warnings. In addition, it also fixes some changes missed in #10 following https://github.com/RebelToolbox/RebelEngine/pull/25 and https://github.com/RebelToolbox/RebelEngine/pull/26.