### PR TITLE
Use Read the Docs command to build Sphinx documents in parallel

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,22 +8,12 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.10"
+  commands:
+    - python -mvirtualenv $READTHEDOCS_VIRTUALENV_PATH
+    - python -m pip install --upgrade --no-cache-dir pip setuptools
+    - python -m pip install --upgrade --no-cache-dir sphinx readthedocs-sphinx-ext
+    - python -m pip install --exists-action=w --no-cache-dir -r requirements.txt
+    - cat conf.py
+    - python -m sphinx -j 4 -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
 
-python:
-  install:
-    - requirements: requirements.txt
-
-sphinx:
-  configuration: conf.py
-
-# Possible options: htmlzip, pdf, epub
-# All disabled for now:
-# - single-page htmlzip is too big to be usable, and requires too much memory.
-# - pdf generates too many latex warnings and the build is killed once logs
-#   reach 4 MB. Could likely be improved if someone is motivated.
-# - epub is too big, and has tons of validation errors which make most readers
-#   treat it as invalid (GH-3862). Also, it's ugly.
-# Hopefully one day we'll have a multi-page HTML zip option, but until
-# then, all offline download options are worthless.
-# (Track https://github.com/readthedocs/readthedocs.org/issues/3242)
 formats: []


### PR DESCRIPTION
Read the Docs, which hosts our online documentation: https://docs.rebeltoolbox.com has [limits](https://docs.readthedocs.io/en/stable/builds.html#build-resources) on the resources available to a build the documentation. Builds will fail if they take longer than 30 minutes. Our builds are currently taking around 30 minutes and have taken longer and failed e.g.: https://readthedocs.org/projects/rebel-documentation/builds/23365172/.

The majority of the time is taken up by the Sphinx build:
```
Date: 2024-02-06T00:39:55.838316Z
...
[rtd-command-info] start-time: 2024-02-06T00:40:38.959622Z, end-time: 2024-02-06T01:10:03.989662Z, duration: 1765, exit-code: 0
python -m sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
```
Everything before the Sphinx build is taking less than a minute, but the build is taking close to half an hour, with the failed build exceeding the 30 minute limit:
```
Date: 2024-02-06T18:28:43.194512Z
...
[rtd-command-info] start-time: 2024-02-06T18:29:29.603841Z, end-time: 2024-02-06T19:00:33.754201Z, duration: 1864, exit-code: 137
python -m sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
```

This PR attempts to use a custom build command to run the Sphinx build using multiple parallel jobs. I have tested this command using a GitHub build test, which ran for only 11 minutes! However, this can only be tested on Read the Docs once the PR is created.
 