### PR TITLE
Include deleted files in automated Rebel Engine API update

### DIFF
--- a/.github/workflows/update-rebel-engine-api.yaml
+++ b/.github/workflows/update-rebel-engine-api.yaml
@@ -91,7 +91,7 @@ jobs:
           git config user.name "Rebel Documentation"
           git config user.email "158277139+RebelDocumentation@users.noreply.github.com"
           echo "Adding files"
-          git add api/*
+          git add api/
           echo "Creating commit"
           git commit -m "Update Rebel Engine API"
           echo "Pushing changes"


### PR DESCRIPTION
Currently, when adding changes to the Rebel Engine API, the automated workflow does not include deleted files.

This PR ensures that deleted files are included when adding changes to the commit.