### PR TITLE
Exclude .git directory in Git hook's pre-commit spell check

### DIFF
--- a/_tools/hooks/pre-commit
+++ b/_tools/hooks/pre-commit
@@ -9,7 +9,7 @@ echo "Checking spelling..."
 if ! codespell                           \
     -I _tools/codespell-ignore-words.txt \
     -x _tools/codespell-ignore-lines.txt \
-    --skip="_*","env"
+    --skip=".git","_*","env"
 then
     echo "Spelling errors found."
     echo "Please fix the spelling errors and try again."


### PR DESCRIPTION
Currently, the Git pre-commit hook will fail, because it includes the hidden `.git` directory when checking spelling. This PR updates the pre-commit hook `codespell` `--skip` option to also skip the `.git` directory.