### PR TITLE
Fix broken link to new Build for Android page

### DIFF
--- a/tutorials/export/exporting_for_android.rst
+++ b/tutorials/export/exporting_for_android.rst
@@ -8,7 +8,7 @@ Exporting for Android
 
     This page describes how to export a Rebel project to Android.
     If you're looking to compile export template binaries from source instead,
-    read :ref:`doc_compiling_for_android`.
+    read :ref:`doc_build_for_android`.
 
 Exporting for Android has fewer requirements than compiling Rebel Engine for Android.
 The following steps detail what is needed to set up the Android SDK and the engine.


### PR DESCRIPTION
#25 created the new [Build for Android page](https://docs.rebeltoolbox.com/en/latest/development/compiling/build_for_android.html). However, it missed one of the links to the old page. This PR corrects the broken link to point to the new Build for Android page.