### PR TITLE
Treat build warnings as errors

### DIFF
--- a/.github/workflows/documentation-checks.yaml
+++ b/.github/workflows/documentation-checks.yaml
@@ -69,4 +69,4 @@ jobs:
         run: |
           #Build dummy documentation
           source env/bin/activate
-          make dummy
+          make dummy SPHINXOPTS="-W --keep-going"


### PR DESCRIPTION
To avoid issues like #28, this PR updates the document checks to treat warnings as errors. It includes the `--keep-going` option to ensure test builds catch all warnings not just the first one.