### PR TITLE
Remove unused sphinx_tabs_nowarn option

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -166,8 +166,6 @@ raw_enabled = False
 # https://sphinx-tabs.readthedocs.io
 # Required by Read the Docs
 
-sphinx_tabs_nowarn = True
-
 
 # 8.2 Sphinx not found extension
 # https://sphinx-notfound-page.readthedocs.io


### PR DESCRIPTION
Removes the unused `sphinx_tabs_nowarn` option, which was removed from Sphinx Tabs in v2:
https://github.com/executablebooks/sphinx-tabs/blob/master/CHANGELOG.md#200---2021-01-24