### PR TITLE
Enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,30 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "0:00"
+    labels:
+      - "PR Type: Technical"
+    pull-request-branch-name:
+      separator: "-"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "1:00"
+    labels:
+      - "PR Type: Technical"
+    pull-request-branch-name:
+      separator: "-"
+    groups:
+      version-updates:
+          patterns:
+             - "*"
+          update-types:
+            - "minor"
+            - "patch"


### PR DESCRIPTION
[Dependabot](https://docs.github.com/en/code-security/dependabot) can be used to automate the updating of Rebel Documentation's dependencies: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates

To enable the automation, this PR creates a `dependabot.yaml` file that configures Dependabot to automatically update:
- The GitHub actions used in our workflows
- The Python libraries used to build Rebel Documentation

Unfortunately, there is no easy way to test this without creating the file and reactively troubleshooting it, but, hopefully, it will work first time. :-)  