### PR TITLE
Fix time value to match dd:dd format

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-      time: "0:00"
+      time: "00:00"
     labels:
       - "PR Type: Technical"
     pull-request-branch-name:
@@ -16,7 +16,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
-      time: "1:00"
+      time: "01:00"
     labels:
       - "PR Type: Technical"
     pull-request-branch-name:


### PR DESCRIPTION
#31 added a `dependabot.yaml` file to enable Dependabot. However, the `dependabot.yaml` file has an error in it:

> Dependabot encountered the following error when parsing your .github/dependabot.yaml:
```
The property '#/updates/0/schedule/time' value "0:00" did not match the regex '^\d\d:\d\d$'
The property '#/updates/1/schedule/time' value "1:00" did not match the regex '^\d\d:\d\d$'
```
> Please update the config file to conform with Dependabot's specification.

This PR updates the `dependabot.yaml` time values to match the expected `dd:dd` format.