### PR TITLE
Re-enable matplotlib logging

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -197,8 +197,4 @@ notfound_context = {
 # 8.3 Sphinx opengraph extension
 # https://github.com/wpilibsuite/sphinxext-opengraph
 
-# Disable matplotlib's font manager logging.
-# Prevents `findfont: Font family 'Roboto' not found.` messages.
-# https://github.com/wpilibsuite/sphinxext-opengraph/issues/115
-logging.getLogger("matplotlib.font_manager").disabled = True
 ogp_site_url = "https://docs.rebeltoolbox.com"


### PR DESCRIPTION
Logging for `matplotlib`'s font manger was disabled, because it was raising multiple `findfont: Font family 'Roboto' not found.` messages. This [issue](https://github.com/wpilibsuite/sphinxext-opengraph/issues/115) was resolved with https://github.com/wpilibsuite/sphinxext-opengraph/pull/116 and included in [release v0.9.1](https://github.com/wpilibsuite/sphinxext-opengraph/releases/tag/v0.9.1), which was applied in #33.

Therefore, this PR re-enables `matplotlib`'s logging.