### PR TITLE
Fix label in automated API update

### DIFF
--- a/.github/workflows/update-rebel-engine-api.yaml
+++ b/.github/workflows/update-rebel-engine-api.yaml
@@ -114,6 +114,6 @@ jobs:
               --head update-rebel-engine-api                                               \
               --title "Update Rebel Engine API"                                            \
               --body "Updates the Rebel Engine API documentation with the latest changes." \
-              --label "PR Type: Enhancement"
+              --label "PR Type: Improvement"
             echo "New Pull Request created"
           fi


### PR DESCRIPTION
#37 added the wrong label. The [`PR Type: Enhancement`](https://github.com/RebelToolbox/RebelDocumentation/issues?q=label%3A%22PR+Type%3A+Enhancement%22) label doesn't exist in the Rebel Documentation; so the automated Pull Request creation fails. This PR sets the correct label: [`PR Type: Improvement`](https://github.com/RebelToolbox/RebelDocumentation/issues?q=label%3A%22PR+Type%3A+Improvement%22).