### PR TITLE
Define html_baseurl manually

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -28,6 +28,7 @@ author = "Rebel Documentation Contributors"
 copyright = "2023, Rebel Documentation Contributors"
 version = os.getenv("READTHEDOCS_VERSION", "1.0")
 release = version
+html_baseurl = os.getenv("READTHEDOCS_CANONICAL_URL", "")
 
 
 # 2. General configuration


### PR DESCRIPTION
Read the Docs has announced that they are deprecating Sphinx context injection at build time for all the projects. The deprecation date is set for Monday, 7th October 2024. After this date, Read the Docs won't install the [`readthedocs-sphinx-ext`](https://pypi.org/project/readthedocs-sphinx-ext/) extension and won't manipulate the project's `conf.py` file. [[1](https://about.readthedocs.com/blog/2024/07/addons-by-default/)]

Specifically, after the deprecation date, Read the Docs will stop defining [`html_baseurl`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_baseurl). Since we're using a canonical custom domain: https://docs.rebeltoolbox.com, we need to define it ourselves to keep the canonical custom domain properly configured.

As suggested, this PR defines `html_baseurl` manually, if, and only if, building on Read the Docs, or, more specifically, `READTHEDOCS_CANONICAL_URL` is defined.

1. https://about.readthedocs.com/blog/2024/07/addons-by-default/