### PR TITLE
Fix spelling

### DIFF
--- a/_tools/codespell-ignore-words.txt
+++ b/_tools/codespell-ignore-words.txt
@@ -1,3 +1,4 @@
 doubleclick
+findn
 inout
 lod

--- a/tutorials/vr/openvr/vr_starter_tutorial_part_one.rst
+++ b/tutorials/vr/openvr/vr_starter_tutorial_part_one.rst
@@ -847,7 +847,7 @@ being picked up.
 Then we call ``apply_impulse`` on the ``held_object`` so that the :ref:`RigidBody <class_RigidBody>` is thrown in the direction of the VR controller's velocity, ``controller_velocity``.
 
 We then check to see if the object held extends a class called ``VR_Interactable_Rigidbody``. If it does, then we call a function called ``dropped`` in ``held_object`` and set
-``held_object.controller`` to ``null``. While we have not made ``VR_Interactable_Rigidbody`` yet, but what this will do is call the ``droppped`` function so the :ref:`RigidBody <class_RigidBody>`
+``held_object.controller`` to ``null``. While we have not made ``VR_Interactable_Rigidbody`` yet, but what this will do is call the ``dropped`` function so the :ref:`RigidBody <class_RigidBody>`
 can do whatever it needs to do when dropped, and we set the ``controller`` variable to ``null`` so that the :ref:`RigidBody <class_RigidBody>` knows that it is not being held.
 
 .. tip:: Don't worry, we will cover ``VR_Interactable_Rigidbody`` after this section!


### PR DESCRIPTION
[Codespell](https://pypi.org/project/codespell/) has identified two new spelling mistakes:
```
./tutorials/vr/openvr/vr_starter_tutorial_part_one.rst:850: droppped ==> dropped
./api/class_string.rst:104: findn ==> find
```
This PR fixes the spelling mistake in [VR starter tutorial part 1](https://docs.rebeltoolbox.com/en/latest/tutorials/vr/openvr/vr_starter_tutorial_part_one.html) and adds `findn` to the ignore words list, because this is a [`String`](https://docs.rebeltoolbox.com/en/latest/api/class_string.html#class-string-method-findn) method name.