### PR TITLE
Remove unneeded html_theme_path option

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -98,10 +98,6 @@ html_theme_options = {
     "logo_only": True,
 }
 
-html_theme_path = [
-    sphinx_rtd_theme.get_html_theme_path(),
-]
-
 html_title = supported_languages[language] % version
 
 html_context = {


### PR DESCRIPTION
Setting the [`html_theme_path`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_theme_path) option for the [Read the Docs Sphinx Theme](https://sphinx-rtd-theme.readthedocs.io/en/stable/index.html) is no longer required, and it has now been officially deprecated:
```
 WARNING: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.
```
This PR removes the legacy setting requirement.
