### PR TITLE
Use the latest version of software at Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,9 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-lts-latest"
   tools:
-    python: "3.10"
+    python: "latest"
 
 python:
   install:


### PR DESCRIPTION
Locking the version of software used provides stability, but it also results in outdated software being used long after it has gone end of life. For example, we locked the version of Python used to 3.10, but Python stopped providing bug-fixes to Python 3.10 in April 2023 (security fixes will continue to be applied until October 2026)[[1](https://peps.python.org/pep-0619/)]. This problem is highlighted when trying to (automatically) update Rebel Documentation to use Sphinx 8.2.1 (#63) which failed, because Sphinx 8.2.0 dropped support for Python 3.10[[2](https://www.sphinx-doc.org/en/master/changes/8.2.html#dependencies)].

There are a lot of advantages to using the latest versions of software. We are already automatically updating the modules used to build Rebel Documentation (#31). This PR will allow Read the Docs to automatically update the version of Ubuntu and Python used to build Rebel Documentation.

References:
[1] PEP 619 – Python 3.10 Release Schedule: https://peps.python.org/pep-0619/
[2] Sphinx 8.2 Change Log: https://www.sphinx-doc.org/en/master/changes/8.2.html#dependencies