### PR TITLE
Fix change of 2D-movement.zip filename

### DIFF
--- a/tutorials/2d/2d_movement.rst
+++ b/tutorials/2d/2d_movement.rst
@@ -354,4 +354,4 @@ You may find these code samples useful as starting points for your own projects.
 Feel free to use them and experiment with them to see what you can make.
 
 You can download this sample project here:
-:download:`2D_movement_demo.zip <files/2d-movement.zip>`
+:download:`2D Movement Demo <files/2d-movement.zip>`


### PR DESCRIPTION
Following #5, this PR updates the description of the link that still used the old filename.